### PR TITLE
Remove positioning styles from components

### DIFF
--- a/src/components/BannerTitle/BannerTitle.styled.tsx
+++ b/src/components/BannerTitle/BannerTitle.styled.tsx
@@ -1,9 +1,5 @@
 import styled from "styled-components";
 
-export const BannerTitleContainer = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
+export const BannerTitleContainer = styled.div``;
 
 export const Title = styled.h1``;

--- a/src/components/Heatmap/Heatmap.styled.tsx
+++ b/src/components/Heatmap/Heatmap.styled.tsx
@@ -1,14 +1,8 @@
 import styled from "styled-components";
 
 export const HeatmapContainer = styled.div`
-  width: 100%;
   margin-top: 30px;
   margin-bottom: 20px;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
 `;
 
 export const HeatmapGrid = styled.div`

--- a/src/components/Inspector/Inspector.styled.tsx
+++ b/src/components/Inspector/Inspector.styled.tsx
@@ -1,13 +1,6 @@
 import styled from "styled-components";
 
-export const InspectorContainer = styled.div`
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  /* background-color: lightblue; */
-`;
+export const InspectorContainer = styled.div``;
 
 export const InspectorTitleWrapper = styled.div`
   width: 1290px;

--- a/src/components/Landing/Landing.styled.tsx
+++ b/src/components/Landing/Landing.styled.tsx
@@ -1,10 +1,6 @@
 import styled from "styled-components";
 
-export const LandingContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
+export const LandingContainer = styled.div``;
 
 export const ParaWrapper = styled.div`
   width: 600px;

--- a/src/components/SearchSubreddit/SearchSubreddit.styled.tsx
+++ b/src/components/SearchSubreddit/SearchSubreddit.styled.tsx
@@ -1,13 +1,6 @@
 import styled from "styled-components";
 
-export const SearchSubredditContainer = styled.div`
-  position: relative;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-`;
+export const SearchSubredditContainer = styled.div``;
 
 export const FlexContainer = styled.div`
   display: flex;

--- a/src/layouts/Home.styled.tsx
+++ b/src/layouts/Home.styled.tsx
@@ -1,6 +1,14 @@
 import styled from "styled-components";
 
+export const HomeContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-items: center;
+`;
+
 export const Description = styled.div`
+  width: 1000px;
   display: flex;
   justify-content: space-around;
   align-items: center;

--- a/src/layouts/UserDashboard.styled.tsx
+++ b/src/layouts/UserDashboard.styled.tsx
@@ -1,8 +1,14 @@
 import styled from "styled-components";
 
-export const UserDashboardContainer = styled.div``;
+export const UserDashboardContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-items: center;
+`;
 
 export const Description = styled.div`
+  width: 1000px;
   display: flex;
   justify-content: space-around;
   align-items: center;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,7 +6,7 @@ import Landing from "../components/Landing/Landing";
 import BannerTitle from "../components/BannerTitle/BannerTitle";
 import SaveSubreddit from "../components/SaveSubreddit/SaveSubreddit";
 import TimeZone from "../components/TimeZone/TimeZone";
-import { Description } from "../layouts/Home.styled";
+import { HomeContainer, Description } from "../layouts/Home.styled";
 
 const Home = () => {
   // const { posts, postCounts } = useContext<any>(FetcherContext);
@@ -41,7 +41,7 @@ const Home = () => {
     }
   }, [posts]);
   return (
-    <>
+    <HomeContainer>
       <BannerTitle>Find the best time to post on Reddit!</BannerTitle>
       <SearchSubreddit
         setPosts={setPosts}
@@ -67,7 +67,7 @@ const Home = () => {
         </>
       )}
       <Landing></Landing>
-    </>
+    </HomeContainer>
   );
 };
 


### PR DESCRIPTION
- Remove positioning styles from individual components to instead handle
  positioning with pages layouts
- Add positioning containers to `Home` and `UserDashboard` to handle
  positioning